### PR TITLE
chore: update hgnc_complete_set download url

### DIFF
--- a/download_urls.yml
+++ b/download_urls.yml
@@ -251,7 +251,7 @@
     count: 10000
 
 - url: 'https://ensembl.org/biomart/martservice?query=<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Query><Query  virtualSchemaName = "default" formatter = "TSV" header = "0" uniqueRows = "0" count = "" datasetConfigVersion = "0.6" ><Dataset name = "hsapiens_gene_ensembl" interface = "default" ><Attribute name = "ensembl_gene_id" /><Attribute name = "ensembl_transcript_id" /><Attribute name = "entrezgene_id" /><Attribute name = "external_gene_name" /></Dataset></Query>'
-- url: 'https://ftp.ebi.ac.uk/pub/databases/genenames/hgnc/json/hgnc_complete_set.json'
+- url: 'https://storage.googleapis.com/public-download-files/hgnc/json/json/hgnc_complete_set.json'
   skip_upstream_check: true  # does not work reliably in tests
   excerpt_strategy:
     strategy: manual

--- a/rules/work/genes/hgnc.smk
+++ b/rules/work/genes/hgnc.smk
@@ -14,7 +14,7 @@ rule genes_hgnc_download:  # -- Download the HGNC data
 
         wget --no-check-certificate \
             -O {output.json} \
-            https://ftp.ebi.ac.uk/pub/databases/genenames/hgnc/json/hgnc_complete_set.json
+            https://storage.googleapis.com/public-download-files/hgnc/json/json/hgnc_complete_set.json
 
         md5sum {output.json} > {output.json_md5}
         """


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated URLs for genomic data sources, including the HGNC complete set now hosted on Google Cloud Storage.
	- Added multiple new URLs related to the gnomAD project, including various VCF files for different chromosomes and versions.

- **Bug Fixes**
	- Removed outdated URLs pointing to OrphaData API endpoints and other genomic data sources.

- **Chores**
	- Marked some URLs with `skip_upstream_check: true` for reliability during tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->